### PR TITLE
Remove redundant element name from filter selector

### DIFF
--- a/jquery.autoresize.js
+++ b/jquery.autoresize.js
@@ -52,7 +52,7 @@
     padding: '0.49em' //this must be about the width of caps W character
   };
 
-  autoResize.resizableFilterSelector = 'textarea,input:not(input[type]),input[type=text],input[type=password]';
+  autoResize.resizableFilterSelector = 'textarea,input:not([type]),input[type=text],input[type=password]';
 
   autoResize.AutoResizer = AutoResizer;
 


### PR DESCRIPTION
This fixes an issue where the following exception could occur deep within Sizzle (jQuery's CSS selector engine).

```
TypeError: 'undefined' is not an object (evaluating 'selector.replace')
```

This bug was discovered while writing some integration tests for Handsontable to run under PhantomJS. The problem did not occur in Chrome. It’d be great if this could make its way up into the next release of Handsontable.
